### PR TITLE
PartyIdentifier: Sacada vista tree sin xml

### DIFF
--- a/party.xml
+++ b/party.xml
@@ -13,11 +13,6 @@ this repository contains the full copyright notices and license terms. -->
             <field name="inherit" ref="party.identifier_form"/>
             <field name="name">identifier_form</field>
         </record>
-        <record model="ir.ui.view" id="identifier_list">
-            <field name="model">party.identifier</field>
-            <field name="type">tree</field>
-            <field name="name">identifier_list</field>
-        </record>
         <record model="ir.ui.view" id="party_afip_vat_country_view_form">
             <field name="model">party.afip.vat.country</field>
             <field name="type">form</field>


### PR DESCRIPTION
Lukio:
Existe la referencia a la vista tree de PartyIdentifier, pero falta el archivo.
Las opciones serían:
1) agregar el archivo 'identifier_list.xml' con el nuevo campo 'vat_country'
2) eliminar la mención a la vista (este commit)
Consideré que no era necesario agregar el campo a la vista tree.
Saludos!
